### PR TITLE
Update github actions for eslint failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,11 @@
-name: Run ESLint
-
-on: [push]
-
+name: CI
+on: push
 jobs:
-  eslint:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: stefanoeb/eslint-action@1.0.2
-        with:
-          files: src/
+    - uses: actions/checkout@v2
+    - name: Install modules
+      run: yarn
+    - name: Run ESLint
+      run: eslint . --ext .js


### PR DESCRIPTION
Previous Action was using: https://github.com/stefanoeb/eslint-action

The repository claims we can use Github Actions for this fully. Its possible this can work for your use case.